### PR TITLE
Add naettUserAgent option

### DIFF
--- a/naett.c
+++ b/naett.c
@@ -265,12 +265,12 @@ naettOption* naettHeader(const char* name, const char* value) {
     return (naettOption*)option;
 }
 
-naettOption* naettUserAgent(const char* method) {
+naettOption* naettUserAgent(const char* userAgent) {
     naettAlloc(InternalOption, option);
     option->numParams = 1;
     InternalParam* param = &option->params[0];
 
-    param->string = method;
+    param->string = userAgent;
     param->offset = offsetof(RequestOptions, userAgent);
     param->setter = stringSetter;
 
@@ -953,9 +953,7 @@ void naettPlatformMakeRequest(InternalResponse* res) {
 
     struct curl_slist* headerList = NULL;
     char uaBuf[512];
-    if (req->options.userAgent) {
-        snprintf(uaBuf, sizeof(uaBuf), "User-Agent: %s", req->options.userAgent ? req->options.userAgent : NAETT_UA);
-    }
+    snprintf(uaBuf, sizeof(uaBuf), "User-Agent: %s", req->options.userAgent ? req->options.userAgent : NAETT_UA);
     headerList = curl_slist_append(headerList, uaBuf);
 
     KVLink* header = req->options.headers;
@@ -1220,7 +1218,7 @@ int naettPlatformInitRequest(InternalRequest* req) {
     req->resource = wcsndup(components.lpszUrlPath, components.dwUrlPathLength + components.dwExtraInfoLength);
     free(url);
 
-    LPWSTR uaBuf = 0;
+    LPWSTR uaBuf = NULL;
     if (req->options.userAgent) {
         uaBuf = winFromUTF8(req->options.userAgent);
     }

--- a/naett.h
+++ b/naett.h
@@ -44,6 +44,8 @@ naettOption* naettBodyReader(naettReadFunc reader, void* userData);
 naettOption* naettBodyWriter(naettWriteFunc writer, void* userData);
 // Sets connection timeout in milliseconds.
 naettOption* naettTimeout(int milliSeconds);
+// Sets the user agent.
+naettOption* naettUserAgent(const char *userAgent);
 
 /**
  * @brief Creates a new request to the specified url.
@@ -53,7 +55,7 @@ naettOption* naettTimeout(int milliSeconds);
 
 /**
  * @brief Creates a new request to the specified url.
- * Uses an array of options rather that varargs. 
+ * Uses an array of options rather than varargs.
  */
 naettReq* naettRequestWithOptions(const char* url, int numOptions, const naettOption** options);
 
@@ -61,7 +63,7 @@ naettReq* naettRequestWithOptions(const char* url, int numOptions, const naettOp
  * @brief Makes a request and returns a response object.
  * The actual request is processed asynchronously, use `naettComplete`
  * to check if the response is completed.
- * 
+ *
  * A request object can be reused multiple times to make requests, but
  * there can be only one active request using the same request object.
  */

--- a/src/naett_android.c
+++ b/src/naett_android.c
@@ -109,7 +109,7 @@ static void* processRequest(void* data) {
 
     {
         jstring name = (*env)->NewStringUTF(env, "User-Agent");
-        jstring value = (*env)->NewStringUTF(env, NAETT_UA);
+        jstring value = (*env)->NewStringUTF(env, req->options.userAgent ? req->options.userAgent : NAETT_UA);
         voidCall(env, connection, "addRequestProperty", "(Ljava/lang/String;Ljava/lang/String;)V", name, value);
         (*env)->DeleteLocalRef(env, name);
         (*env)->DeleteLocalRef(env, value);

--- a/src/naett_core.c
+++ b/src/naett_core.c
@@ -69,7 +69,7 @@ static int defaultBodyReader(void* dest, int bufferSize, void* userData) {
     if (dest == NULL) {
         return buffer->size;
     }
-    
+
     int bytesToRead = buffer->size - buffer->position;
     if (bytesToRead > bufferSize) {
         bytesToRead = bufferSize;
@@ -145,6 +145,18 @@ naettOption* naettHeader(const char* name, const char* value) {
     param->kv.value = value;
     param->offset = offsetof(RequestOptions, headers);
     param->setter = kvSetter;
+
+    return (naettOption*)option;
+}
+
+naettOption* naettUserAgent(const char* method) {
+    naettAlloc(InternalOption, option);
+    option->numParams = 1;
+    InternalParam* param = &option->params[0];
+
+    param->string = method;
+    param->offset = offsetof(RequestOptions, userAgent);
+    param->setter = stringSetter;
 
     return (naettOption*)option;
 }
@@ -249,7 +261,7 @@ naettReq* naettRequest_va(const char* url, int numArgs, ...) {
     if (naettPlatformInitRequest(req)) {
         return (naettReq*)req;
     }
-    
+
     naettFree((naettReq*) req);
     return NULL;
 }
@@ -272,7 +284,7 @@ naettReq* naettRequestWithOptions(const char* url, int numOptions, const naettOp
     if (naettPlatformInitRequest(req)) {
         return (naettReq*)req;
     }
-    
+
     naettFree((naettReq*) req);
     return NULL;
 }

--- a/src/naett_core.c
+++ b/src/naett_core.c
@@ -149,12 +149,12 @@ naettOption* naettHeader(const char* name, const char* value) {
     return (naettOption*)option;
 }
 
-naettOption* naettUserAgent(const char* method) {
+naettOption* naettUserAgent(const char* userAgent) {
     naettAlloc(InternalOption, option);
     option->numParams = 1;
     InternalParam* param = &option->params[0];
 
-    param->string = method;
+    param->string = userAgent;
     param->offset = offsetof(RequestOptions, userAgent);
     param->setter = stringSetter;
 

--- a/src/naett_internal.h
+++ b/src/naett_internal.h
@@ -1,14 +1,15 @@
 #ifndef NAETT_INTERNAL_H
 #define NAETT_INTERNAL_H
 
-#ifdef _MSC_VER 
+#ifdef _MSC_VER
     #define strcasecmp _stricmp
-    #define min(a,b) (((a)<(b))?(a):(b))
+    #undef strdup
     #define strdup _strdup
 #endif
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <windows.h>
 #include <winhttp.h>
 #define __WINDOWS__ 1
@@ -51,6 +52,7 @@ typedef struct Buffer {
 
 typedef struct {
     const char* method;
+    const char* userAgent;
     int timeoutMS;
     naettReadFunc bodyReader;
     void* bodyReaderData;

--- a/src/naett_linux.c
+++ b/src/naett_linux.c
@@ -193,7 +193,11 @@ void naettPlatformMakeRequest(InternalResponse* res) {
     setupMethod(c, req->options.method);
 
     struct curl_slist* headerList = NULL;
-    headerList = curl_slist_append(headerList, "User-Agent: Naett/1.0");
+    char uaBuf[512];
+    if (req->options.userAgent) {
+        snprintf(uaBuf, sizeof(uaBuf), "User-Agent: %s", req->options.userAgent ? req->options.userAgent : NAETT_UA);
+    }
+    headerList = curl_slist_append(headerList, uaBuf);
 
     KVLink* header = req->options.headers;
     size_t bufferSize = 0;

--- a/src/naett_linux.c
+++ b/src/naett_linux.c
@@ -194,9 +194,7 @@ void naettPlatformMakeRequest(InternalResponse* res) {
 
     struct curl_slist* headerList = NULL;
     char uaBuf[512];
-    if (req->options.userAgent) {
-        snprintf(uaBuf, sizeof(uaBuf), "User-Agent: %s", req->options.userAgent ? req->options.userAgent : NAETT_UA);
-    }
+    snprintf(uaBuf, sizeof(uaBuf), "User-Agent: %s", req->options.userAgent ? req->options.userAgent : NAETT_UA);
     headerList = curl_slist_append(headerList, uaBuf);
 
     KVLink* header = req->options.headers;

--- a/src/naett_osx.c
+++ b/src/naett_osx.c
@@ -42,7 +42,7 @@ int naettPlatformInitRequest(InternalRequest* req) {
 
     {
         id name = NSString("User-Agent");
-        id value = NSString(NAETT_UA);
+        id value = NSString(req->options.userAgent ? req->options.userAgent : NAETT_UA);
         objc_msgSend_t(void, id, id)(request, sel("setValue:forHTTPHeaderField:"), value, name);
     }
 
@@ -129,7 +129,7 @@ static id createDelegate() {
     if (!TaskDelegateClass) {
         TaskDelegateClass = objc_allocateClassPair((Class)objc_getClass("NSObject"), "naettTaskDelegate", 0);
         class_addProtocol(TaskDelegateClass, objc_getProtocol("NSURLSessionDataDelegate"));
-        
+
         addMethod(TaskDelegateClass, "URLSession:dataTask:didReceiveData:", didReceiveData, "v@:@@@");
         addMethod(TaskDelegateClass, "URLSession:task:didCompleteWithError:", didComplete, "v@:@@@");
         addIvar(TaskDelegateClass, "response", sizeof(void*), "^v");

--- a/src/naett_win.c
+++ b/src/naett_win.c
@@ -227,7 +227,7 @@ int naettPlatformInitRequest(InternalRequest* req) {
     req->resource = wcsndup(components.lpszUrlPath, components.dwUrlPathLength + components.dwExtraInfoLength);
     free(url);
 
-    LPWSTR uaBuf = 0;
+    LPWSTR uaBuf = NULL;
     if (req->options.userAgent) {
         uaBuf = winFromUTF8(req->options.userAgent);
     }


### PR DESCRIPTION
Lets you specify the user agent per request, sometimes useful.

Tried to find the optimal way to do it on each platform.

Also, fixes a bunch of warnings on MSVC.

~~Testing on Mac and Linux coming up.~~ works.

Fixes #15 