### PR TITLE
Add naettGetTotalBytesRead

### DIFF
--- a/naett.h
+++ b/naett.h
@@ -53,7 +53,7 @@ naettOption* naettTimeout(int milliSeconds);
 
 /**
  * @brief Creates a new request to the specified url.
- * Uses an array of options rather that varargs. 
+ * Uses an array of options rather that varargs.
  */
 naettReq* naettRequestWithOptions(const char* url, int numOptions, const naettOption** options);
 
@@ -61,7 +61,7 @@ naettReq* naettRequestWithOptions(const char* url, int numOptions, const naettOp
  * @brief Makes a request and returns a response object.
  * The actual request is processed asynchronously, use `naettComplete`
  * to check if the response is completed.
- * 
+ *
  * A request object can be reused multiple times to make requests, but
  * there can be only one active request using the same request object.
  */
@@ -108,6 +108,13 @@ const void* naettGetBody(naettRes* response, int* outSize);
  * @brief Returns the HTTP header value for the specified header name.
  */
 const char* naettGetHeader(naettRes* response, const char* name);
+
+/**
+ * @brief Returns how many bytes have been read from the response so far,
+ * and the integer pointed to by totalSize gets the Content-Length if available,
+ * or -1 if not (or 0 if headers have not been read yet).
+ */
+int naettGetTotalBytesRead(naettRes* response, int* totalSize);
 
 /**
  * @brief Enumerates all response headers as long as the `lister`

--- a/src/naett_android.c
+++ b/src/naett_android.c
@@ -171,6 +171,7 @@ static void* processRequest(void* data) {
     jarray headers = call(env, headerSet, "toArray", "()[Ljava/lang/Object;");
     jsize headerCount = (*env)->GetArrayLength(env, headers);
 
+    KVLink *firstHeader = NULL;
     for (int i = 0; i < headerCount; i++) {
         jstring name = (*env)->GetObjectArrayElement(env, headers, i);
         if (name == NULL) {
@@ -185,8 +186,8 @@ static void* processRequest(void* data) {
         naettAlloc(KVLink, node);
         node->key = strdup(nameString);
         node->value = strdup(valueString);
-        node->next = res->headers;
-        res->headers = node;
+        node->next = firstHeader;
+        firstHeader = node;
 
         (*env)->ReleaseStringUTFChars(env, name, nameString);
         (*env)->ReleaseStringUTFChars(env, value, valueString);
@@ -195,6 +196,7 @@ static void* processRequest(void* data) {
         (*env)->DeleteLocalRef(env, value);
         (*env)->DeleteLocalRef(env, values);
     }
+    res->headers = firstHeader;
 
     int statusCode = intCall(env, connection, "getResponseCode", "()I");
 

--- a/src/naett_android.c
+++ b/src/naett_android.c
@@ -198,6 +198,11 @@ static void* processRequest(void* data) {
     }
     res->headers = firstHeader;
 
+    const char *contentLength = naettGetHeader(res, "Content-Length");
+    if (!contentLength || sscanf(contentLength, "%d", &res->contentLength) != 1) {
+        res->contentLength = -1;
+    }
+
     int statusCode = intCall(env, connection, "getResponseCode", "()I");
 
     jobject inputStream = NULL;
@@ -221,9 +226,11 @@ static void* processRequest(void* data) {
         }
         if (bytesRead < 0) {
             break;
+        } else if (bytesRead > 0) {
+            (*env)->GetByteArrayRegion(env, buffer, 0, bytesRead, (jbyte*) byteBuffer);
+            req->options.bodyWriter(byteBuffer, bytesRead, req->options.bodyWriterData);
+            res->totalBytesRead += bytesRead;
         }
-        (*env)->GetByteArrayRegion(env, buffer, 0, bytesRead, (jbyte*) byteBuffer);
-        req->options.bodyWriter(byteBuffer, bytesRead, req->options.bodyWriterData);
     } while (!res->closeRequested);
 
     voidCall(env, inputStream, "close", "()V");

--- a/src/naett_core.c
+++ b/src/naett_core.c
@@ -69,7 +69,7 @@ static int defaultBodyReader(void* dest, int bufferSize, void* userData) {
     if (dest == NULL) {
         return buffer->size;
     }
-    
+
     int bytesToRead = buffer->size - buffer->position;
     if (bytesToRead > bufferSize) {
         bytesToRead = bufferSize;
@@ -249,7 +249,7 @@ naettReq* naettRequest_va(const char* url, int numArgs, ...) {
     if (naettPlatformInitRequest(req)) {
         return (naettReq*)req;
     }
-    
+
     naettFree((naettReq*) req);
     return NULL;
 }
@@ -272,7 +272,7 @@ naettReq* naettRequestWithOptions(const char* url, int numOptions, const naettOp
     if (naettPlatformInitRequest(req)) {
         return (naettReq*)req;
     }
-    
+
     naettFree((naettReq*) req);
     return NULL;
 }
@@ -300,6 +300,15 @@ const void* naettGetBody(naettRes* response, int* size) {
     InternalResponse* res = (InternalResponse*)response;
     *size = res->body.size;
     return res->body.data;
+}
+
+int naettGetTotalBytesRead(naettRes* response, int* totalSize) {
+    assert(response != NULL);
+    assert(totalSize != NULL);
+
+    InternalResponse* res = (InternalResponse*)response;
+    *totalSize = res->contentLength;
+    return res->totalBytesRead;
 }
 
 const char* naettGetHeader(naettRes* response, const char* name) {

--- a/src/naett_internal.h
+++ b/src/naett_internal.h
@@ -1,7 +1,7 @@
 #ifndef NAETT_INTERNAL_H
 #define NAETT_INTERNAL_H
 
-#ifdef _MSC_VER 
+#ifdef _MSC_VER
     #define strcasecmp _stricmp
     #define min(a,b) (((a)<(b))?(a):(b))
     #define strdup _strdup

--- a/src/naett_internal.h
+++ b/src/naett_internal.h
@@ -84,6 +84,8 @@ typedef struct {
     int complete;
     KVLink* headers;
     Buffer body;
+    int contentLength;  // 0 if headers not read, -1 if Content-Length missing.
+    int totalBytesRead;
 #if __APPLE__
     id session;
 #endif

--- a/src/naett_linux.c
+++ b/src/naett_linux.c
@@ -48,6 +48,7 @@ static void* curlWorker(void* data) {
         int bytesRead = read(handleReadFD, newHandle.buf, sizeof(newHandle.buf) - newHandlePos);
         if (bytesRead > 0) {
             newHandlePos += bytesRead;
+            res->totalBytesRead += bytesRead;
         }
         if (newHandlePos == sizeof(newHandle.buf)) {
             curl_multi_add_handle(mc, newHandle.handle);

--- a/src/naett_osx.c
+++ b/src/naett_osx.c
@@ -97,13 +97,15 @@ void didReceiveData(id self, SEL _sel, id session, id dataTask, id data) {
 
         objc_msgSend_t(NSInteger, id*, id*, NSUInteger)(
             allHeaders, sel("getObjects:andKeys:count:"), headerValues, headerNames, headerCount);
+        KVLink *firstHeader = NULL;
         for (int i = 0; i < headerCount; i++) {
             naettAlloc(KVLink, node);
             node->key = strdup(objc_msgSend_t(const char*)(headerNames[i], sel("UTF8String")));
             node->value = strdup(objc_msgSend_t(const char*)(headerValues[i], sel("UTF8String")));
-            node->next = res->headers;
-            res->headers = node;
+            node->next = firstHeader;
+            firstHeader = node;
         }
+        res->headers = firstHeader;
     }
 
     const void* bytes = objc_msgSend_t(const void*)(data, sel("bytes"));
@@ -129,7 +131,7 @@ static id createDelegate() {
     if (!TaskDelegateClass) {
         TaskDelegateClass = objc_allocateClassPair((Class)objc_getClass("NSObject"), "naettTaskDelegate", 0);
         class_addProtocol(TaskDelegateClass, objc_getProtocol("NSURLSessionDataDelegate"));
-        
+
         addMethod(TaskDelegateClass, "URLSession:dataTask:didReceiveData:", didReceiveData, "v@:@@@");
         addMethod(TaskDelegateClass, "URLSession:task:didCompleteWithError:", didComplete, "v@:@@@");
         addIvar(TaskDelegateClass, "response", sizeof(void*), "^v");

--- a/src/naett_osx.c
+++ b/src/naett_osx.c
@@ -106,11 +106,18 @@ void didReceiveData(id self, SEL _sel, id session, id dataTask, id data) {
             firstHeader = node;
         }
         res->headers = firstHeader;
+
+        const char *contentLength = naettGetHeader(res, "Content-Length");
+        if (!contentLength || sscanf(contentLength, "%d", &res->contentLength) != 1) {
+            res->contentLength = -1;
+        }
     }
 
     const void* bytes = objc_msgSend_t(const void*)(data, sel("bytes"));
     NSUInteger length = objc_msgSend_t(NSUInteger)(data, sel("length"));
+
     res->request->options.bodyWriter(bytes, length, res->request->options.bodyWriterData);
+    res->totalBytesRead += (int)length;
 
     release(p);
 }

--- a/src/naett_win.c
+++ b/src/naett_win.c
@@ -113,6 +113,11 @@ static void callback(HINTERNET request,
             unpackHeaders(res, buffer);
             free(buffer);
 
+            const char *contentLength = naettGetHeader(res, "Content-Length");
+            if (!contentLength || sscanf(contentLength, "%d", &res->contentLength) != 1) {
+                res->contentLength = -1;
+            }
+
             DWORD statusCode = 0;
             DWORD statusCodeSize = sizeof(statusCode);
 
@@ -153,7 +158,7 @@ static void callback(HINTERNET request,
                 res->code = naettReadError;
                 res->complete = 1;
             }
-
+            res->totalBytesRead += (int)bytesRead;
             res->bytesLeft -= bytesRead;
             if (res->bytesLeft > 0) {
                 size_t bytesToRead = min(res->bytesLeft, sizeof(res->buffer));

--- a/src/naett_win.c
+++ b/src/naett_win.c
@@ -65,6 +65,7 @@ static LPCWSTR packHeaders(InternalRequest* req) {
 
 static void unpackHeaders(InternalResponse* res, LPWSTR packed) {
     int len = 0;
+    KVLink* firstHeader = NULL;
     while ((len = wcslen(packed)) != 0) {
         char* header = winToUTF8(packed);
         char* split = strchr(header, ':');
@@ -77,12 +78,13 @@ static void unpackHeaders(InternalResponse* res, LPWSTR packed) {
             naettAlloc(KVLink, node);
             node->key = strdup(header);
             node->value = strdup(split);
-            node->next = res->headers;
-            res->headers = node;
+            node->next = firstHeader;
+            firstHeader = node;
         }
         free(header);
         packed += len + 1;
     }
+    res->headers = firstHeader;
 }
 
 static void callback(HINTERNET request,


### PR DESCRIPTION
This lets you implement a progress bar for downloads safely and efficiently by calling naettGetTotalBytesRead after checking naettCompleted and finding out it's not done yet.

The first commit makes sure that res->headers only gets written to once by the various backends. This is not actually needed for the two later commits, and still doesn't technically safe to read headers before the full request is complete, but it's still good practice and probably a slight performance improvement. Not implemented in linux.c though because it's less convenient to do there.

Fixes #16 