### PR TITLE
Fix build on 32-bit Windows by specifying CALLBACK calling convention.

### DIFF
--- a/naett.c
+++ b/naett.c
@@ -1060,7 +1060,7 @@ static void unpackHeaders(InternalResponse* res, LPWSTR packed) {
     }
 }
 
-static void callback(HINTERNET request,
+static void CALLBACK callback(HINTERNET request,
     DWORD_PTR context,
     DWORD status,
     LPVOID statusInformation,

--- a/src/naett_win.c
+++ b/src/naett_win.c
@@ -85,7 +85,7 @@ static void unpackHeaders(InternalResponse* res, LPWSTR packed) {
     }
 }
 
-static void callback(HINTERNET request,
+static void CALLBACK callback(HINTERNET request,
     DWORD_PTR context,
     DWORD status,
     LPVOID statusInformation,


### PR DESCRIPTION
n/t