### PR TITLE
Add naettGetTotalBytesRead

### DIFF
--- a/naett.c
+++ b/naett.c
@@ -1247,11 +1247,8 @@ int naettPlatformInitRequest(InternalRequest* req) {
     req->resource = wcsndup(components.lpszUrlPath, components.dwUrlPathLength + components.dwExtraInfoLength);
     free(url);
 
-    LPWSTR uaBuf = NULL;
-    if (req->options.userAgent) {
-        uaBuf = winFromUTF8(req->options.userAgent);
-    }
-    req->session = WinHttpOpen((uaBuf ? uaBuf : _T(NAETT_UA)),
+    LPWSTR uaBuf = winFromUTF8(req->options.userAgent ? req->options.userAgent : NAETT_UA);
+    req->session = WinHttpOpen(uaBuf,
         WINHTTP_ACCESS_TYPE_NO_PROXY,
         WINHTTP_NO_PROXY_NAME,
         WINHTTP_NO_PROXY_BYPASS,

--- a/naett.c
+++ b/naett.c
@@ -7,16 +7,20 @@
 
 #ifdef _MSC_VER
     #define strcasecmp _stricmp
-    #define min(a,b) (((a)<(b))?(a):(b))
     #undef strdup
     #define strdup _strdup
 #endif
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <windows.h>
 #include <winhttp.h>
 #define __WINDOWS__ 1
+#endif
+
+#ifdef _MSC_VER
+	#define min(a, b) (((a) < (b)) ? (a) : (b))
 #endif
 
 #if __linux__ && !__ANDROID__

--- a/naett.c
+++ b/naett.c
@@ -1251,7 +1251,7 @@ int naettPlatformInitRequest(InternalRequest* req) {
     if (req->options.userAgent) {
         uaBuf = winFromUTF8(req->options.userAgent);
     }
-    req->session = WinHttpOpen(uaBuf ? (LPCWSTR)uaBuf : _T(NAETT_UA),
+    req->session = WinHttpOpen((uaBuf ? uaBuf : _T(NAETT_UA)),
         WINHTTP_ACCESS_TYPE_NO_PROXY,
         WINHTTP_NO_PROXY_NAME,
         WINHTTP_NO_PROXY_BYPASS,

--- a/naett.c
+++ b/naett.c
@@ -884,7 +884,7 @@ static size_t writeCallback(char* ptr, size_t size, size_t numItems, void* userD
     InternalResponse* res = (InternalResponse*)userData;
     InternalRequest* req = res->request;
     size_t bytesWritten = req->options.bodyWriter(ptr, size * numItems, req->options.bodyWriterData);
-    req->totalBytesRead += bytesWritten;
+    res->totalBytesRead += bytesWritten;
     return bytesWritten;
 }
 

--- a/naett.c
+++ b/naett.c
@@ -20,7 +20,7 @@
 #endif
 
 #ifdef _MSC_VER
-	#define min(a, b) (((a) < (b)) ? (a) : (b))
+    #define min(a,b) (((a) < (b)) ? (a) : (b))
 #endif
 
 #if __linux__ && !__ANDROID__

--- a/naett.c
+++ b/naett.c
@@ -1156,7 +1156,10 @@ static void CALLBACK callback(HINTERNET request,
                 break;
             }
 
-            size_t bytesToRead = min(res->bytesLeft, sizeof(res->buffer));
+            size_t bytesToRead = res->bytesLeft;
+            if (bytesToRead > sizeof(res->buffer)) {
+                bytesToRead = sizeof(res->buffer);
+            }
             if (!WinHttpReadData(request, res->buffer, (DWORD)bytesToRead, NULL)) {
                 res->code = naettReadError;
                 res->complete = 1;
@@ -1174,7 +1177,10 @@ static void CALLBACK callback(HINTERNET request,
             res->totalBytesRead += (int)bytesRead;
             res->bytesLeft -= bytesRead;
             if (res->bytesLeft > 0) {
-                size_t bytesToRead = min(res->bytesLeft, sizeof(res->buffer));
+                size_t bytesToRead = res->bytesLeft;
+                if (bytesToRead > sizeof(res->buffer)) {
+                    bytesToRead = sizeof(res->buffer);
+                }
                 if (!WinHttpReadData(request, res->buffer, (DWORD)bytesToRead, NULL)) {
                     res->code = naettReadError;
                     res->complete = 1;

--- a/naett.c
+++ b/naett.c
@@ -831,7 +831,6 @@ static void* curlWorker(void* data) {
         int bytesRead = read(handleReadFD, newHandle.buf, sizeof(newHandle.buf) - newHandlePos);
         if (bytesRead > 0) {
             newHandlePos += bytesRead;
-            res->totalBytesRead += bytesRead;
         }
         if (newHandlePos == sizeof(newHandle.buf)) {
             curl_multi_add_handle(mc, newHandle.handle);
@@ -884,7 +883,9 @@ static size_t readCallback(char* buffer, size_t size, size_t numItems, void* use
 static size_t writeCallback(char* ptr, size_t size, size_t numItems, void* userData) {
     InternalResponse* res = (InternalResponse*)userData;
     InternalRequest* req = res->request;
-    return req->options.bodyWriter(ptr, size * numItems, req->options.bodyWriterData);
+    size_t bytesWritten = req->options.bodyWriter(ptr, size * numItems, req->options.bodyWriterData);
+    req->totalBytesRead += bytesWritten;
+    return bytesWritten;
 }
 
 #define METHOD(A, B, C) (((A) << 16) | ((B) << 8) | (C))

--- a/naett.c
+++ b/naett.c
@@ -7,13 +7,13 @@
 
 #ifdef _MSC_VER
     #define strcasecmp _stricmp
+    #define min(a,b) (((a)<(b))?(a):(b))
     #undef strdup
     #define strdup _strdup
 #endif
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
 #include <windows.h>
 #include <winhttp.h>
 #define __WINDOWS__ 1
@@ -1156,10 +1156,7 @@ static void CALLBACK callback(HINTERNET request,
                 break;
             }
 
-            size_t bytesToRead = res->bytesLeft;
-            if (bytesToRead > sizeof(res->buffer)) {
-                bytesToRead = sizeof(res->buffer);
-            }
+            size_t bytesToRead = min(res->bytesLeft, sizeof(res->buffer));
             if (!WinHttpReadData(request, res->buffer, (DWORD)bytesToRead, NULL)) {
                 res->code = naettReadError;
                 res->complete = 1;
@@ -1177,10 +1174,7 @@ static void CALLBACK callback(HINTERNET request,
             res->totalBytesRead += (int)bytesRead;
             res->bytesLeft -= bytesRead;
             if (res->bytesLeft > 0) {
-                size_t bytesToRead = res->bytesLeft;
-                if (bytesToRead > sizeof(res->buffer)) {
-                    bytesToRead = sizeof(res->buffer);
-                }
+                size_t bytesToRead = min(res->bytesLeft, sizeof(res->buffer));
                 if (!WinHttpReadData(request, res->buffer, (DWORD)bytesToRead, NULL)) {
                     res->code = naettReadError;
                     res->complete = 1;

--- a/naett.h
+++ b/naett.h
@@ -112,6 +112,13 @@ const void* naettGetBody(naettRes* response, int* outSize);
 const char* naettGetHeader(naettRes* response, const char* name);
 
 /**
+ * @brief Returns how many bytes have been read from the response so far,
+ * and the integer pointed to by totalSize gets the Content-Length if available,
+ * or -1 if not (or 0 if headers have not been read yet).
+ */
+int naettGetTotalBytesRead(naettRes* response, int* totalSize);
+
+/**
  * @brief Enumerates all response headers as long as the `lister`
  * returns true.
  */

--- a/src/naett_android.c
+++ b/src/naett_android.c
@@ -171,6 +171,7 @@ static void* processRequest(void* data) {
     jarray headers = call(env, headerSet, "toArray", "()[Ljava/lang/Object;");
     jsize headerCount = (*env)->GetArrayLength(env, headers);
 
+    KVLink *firstHeader = NULL;
     for (int i = 0; i < headerCount; i++) {
         jstring name = (*env)->GetObjectArrayElement(env, headers, i);
         if (name == NULL) {
@@ -185,8 +186,8 @@ static void* processRequest(void* data) {
         naettAlloc(KVLink, node);
         node->key = strdup(nameString);
         node->value = strdup(valueString);
-        node->next = res->headers;
-        res->headers = node;
+        node->next = firstHeader;
+        firstHeader = node;
 
         (*env)->ReleaseStringUTFChars(env, name, nameString);
         (*env)->ReleaseStringUTFChars(env, value, valueString);
@@ -195,6 +196,7 @@ static void* processRequest(void* data) {
         (*env)->DeleteLocalRef(env, value);
         (*env)->DeleteLocalRef(env, values);
     }
+    res->headers = firstHeader;
 
     int statusCode = intCall(env, connection, "getResponseCode", "()I");
 

--- a/src/naett_core.c
+++ b/src/naett_core.c
@@ -314,6 +314,15 @@ const void* naettGetBody(naettRes* response, int* size) {
     return res->body.data;
 }
 
+int naettGetTotalBytesRead(naettRes* response, int* totalSize) {
+    assert(response != NULL);
+    assert(totalSize != NULL);
+
+    InternalResponse* res = (InternalResponse*)response;
+    *totalSize = res->contentLength;
+    return res->totalBytesRead;
+}
+
 const char* naettGetHeader(naettRes* response, const char* name) {
     assert(response != NULL);
     assert(name != NULL);

--- a/src/naett_internal.h
+++ b/src/naett_internal.h
@@ -12,11 +12,10 @@
 #define NOMINMAX
 #include <windows.h>
 #include <winhttp.h>
-#define __WINDOWS__ 1
+#ifndef min
+    #define min(x,y) ((x) < (y) ? (x) : (y))
 #endif
-
-#ifdef _MSC_VER
-    #define min(a,b) (((a) < (b)) ? (a) : (b))
+#define __WINDOWS__ 1
 #endif
 
 #if __linux__ && !__ANDROID__

--- a/src/naett_internal.h
+++ b/src/naett_internal.h
@@ -3,16 +3,20 @@
 
 #ifdef _MSC_VER
     #define strcasecmp _stricmp
-    #define min(a,b) (((a)<(b))?(a):(b))
     #undef strdup
     #define strdup _strdup
 #endif
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <windows.h>
 #include <winhttp.h>
 #define __WINDOWS__ 1
+#endif
+
+#ifdef _MSC_VER
+    #define min(a,b) (((a)<(b))?(a):(b))
 #endif
 
 #if __linux__ && !__ANDROID__

--- a/src/naett_internal.h
+++ b/src/naett_internal.h
@@ -16,7 +16,7 @@
 #endif
 
 #ifdef _MSC_VER
-    #define min(a,b) (((a)<(b))?(a):(b))
+    #define min(a,b) (((a) < (b)) ? (a) : (b))
 #endif
 
 #if __linux__ && !__ANDROID__

--- a/src/naett_internal.h
+++ b/src/naett_internal.h
@@ -3,13 +3,13 @@
 
 #ifdef _MSC_VER
     #define strcasecmp _stricmp
+    #define min(a,b) (((a)<(b))?(a):(b))
     #undef strdup
     #define strdup _strdup
 #endif
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
 #include <windows.h>
 #include <winhttp.h>
 #define __WINDOWS__ 1

--- a/src/naett_internal.h
+++ b/src/naett_internal.h
@@ -86,6 +86,8 @@ typedef struct {
     int complete;
     KVLink* headers;
     Buffer body;
+    int contentLength;  // 0 if headers not read, -1 if Content-Length missing.
+    int totalBytesRead;
 #if __APPLE__
     id session;
 #endif

--- a/src/naett_linux.c
+++ b/src/naett_linux.c
@@ -48,6 +48,7 @@ static void* curlWorker(void* data) {
         int bytesRead = read(handleReadFD, newHandle.buf, sizeof(newHandle.buf) - newHandlePos);
         if (bytesRead > 0) {
             newHandlePos += bytesRead;
+            res->totalBytesRead += bytesRead;
         }
         if (newHandlePos == sizeof(newHandle.buf)) {
             curl_multi_add_handle(mc, newHandle.handle);

--- a/src/naett_linux.c
+++ b/src/naett_linux.c
@@ -101,7 +101,7 @@ static size_t writeCallback(char* ptr, size_t size, size_t numItems, void* userD
     InternalResponse* res = (InternalResponse*)userData;
     InternalRequest* req = res->request;
     size_t bytesWritten = req->options.bodyWriter(ptr, size * numItems, req->options.bodyWriterData);
-    req->totalBytesRead += bytesWritten;
+    res->totalBytesRead += bytesWritten;
     return bytesWritten;
 }
 

--- a/src/naett_linux.c
+++ b/src/naett_linux.c
@@ -48,7 +48,6 @@ static void* curlWorker(void* data) {
         int bytesRead = read(handleReadFD, newHandle.buf, sizeof(newHandle.buf) - newHandlePos);
         if (bytesRead > 0) {
             newHandlePos += bytesRead;
-            res->totalBytesRead += bytesRead;
         }
         if (newHandlePos == sizeof(newHandle.buf)) {
             curl_multi_add_handle(mc, newHandle.handle);
@@ -101,7 +100,9 @@ static size_t readCallback(char* buffer, size_t size, size_t numItems, void* use
 static size_t writeCallback(char* ptr, size_t size, size_t numItems, void* userData) {
     InternalResponse* res = (InternalResponse*)userData;
     InternalRequest* req = res->request;
-    return req->options.bodyWriter(ptr, size * numItems, req->options.bodyWriterData);
+    size_t bytesWritten = req->options.bodyWriter(ptr, size * numItems, req->options.bodyWriterData);
+    req->totalBytesRead += bytesWritten;
+    return bytesWritten;
 }
 
 #define METHOD(A, B, C) (((A) << 16) | ((B) << 8) | (C))

--- a/src/naett_osx.c
+++ b/src/naett_osx.c
@@ -106,11 +106,18 @@ void didReceiveData(id self, SEL _sel, id session, id dataTask, id data) {
             firstHeader = node;
         }
         res->headers = firstHeader;
+
+        const char *contentLength = naettGetHeader((naettRes *)res, "Content-Length");
+        if (!contentLength || sscanf(contentLength, "%d", &res->contentLength) != 1) {
+            res->contentLength = -1;
+        }
     }
 
     const void* bytes = objc_msgSend_t(const void*)(data, sel("bytes"));
     NSUInteger length = objc_msgSend_t(NSUInteger)(data, sel("length"));
+
     res->request->options.bodyWriter(bytes, length, res->request->options.bodyWriterData);
+    res->totalBytesRead += (int)length;
 
     release(p);
 }

--- a/src/naett_osx.c
+++ b/src/naett_osx.c
@@ -97,13 +97,15 @@ void didReceiveData(id self, SEL _sel, id session, id dataTask, id data) {
 
         objc_msgSend_t(NSInteger, id*, id*, NSUInteger)(
             allHeaders, sel("getObjects:andKeys:count:"), headerValues, headerNames, headerCount);
+        KVLink *firstHeader = NULL;
         for (int i = 0; i < headerCount; i++) {
             naettAlloc(KVLink, node);
             node->key = strdup(objc_msgSend_t(const char*)(headerNames[i], sel("UTF8String")));
             node->value = strdup(objc_msgSend_t(const char*)(headerValues[i], sel("UTF8String")));
-            node->next = res->headers;
-            res->headers = node;
+            node->next = firstHeader;
+            firstHeader = node;
         }
+        res->headers = firstHeader;
     }
 
     const void* bytes = objc_msgSend_t(const void*)(data, sel("bytes"));

--- a/src/naett_win.c
+++ b/src/naett_win.c
@@ -231,11 +231,8 @@ int naettPlatformInitRequest(InternalRequest* req) {
     req->resource = wcsndup(components.lpszUrlPath, components.dwUrlPathLength + components.dwExtraInfoLength);
     free(url);
 
-    LPWSTR uaBuf = NULL;
-    if (req->options.userAgent) {
-        uaBuf = winFromUTF8(req->options.userAgent);
-    }
-    req->session = WinHttpOpen((uaBuf ? uaBuf : _T(NAETT_UA)),
+    LPWSTR uaBuf = winFromUTF8(req->options.userAgent ? req->options.userAgent : NAETT_UA);
+    req->session = WinHttpOpen(uaBuf,
         WINHTTP_ACCESS_TYPE_NO_PROXY,
         WINHTTP_NO_PROXY_NAME,
         WINHTTP_NO_PROXY_BYPASS,

--- a/src/naett_win.c
+++ b/src/naett_win.c
@@ -88,11 +88,8 @@ static void unpackHeaders(InternalResponse* res, LPWSTR packed) {
     res->headers = firstHeader;
 }
 
-static void CALLBACK callback(HINTERNET request,
-    DWORD_PTR context,
-    DWORD status,
-    LPVOID statusInformation,
-    DWORD statusInfoLength) {
+static void CALLBACK
+callback(HINTERNET request, DWORD_PTR context, DWORD status, LPVOID statusInformation, DWORD statusInfoLength) {
     InternalResponse* res = (InternalResponse*)context;
 
     switch (status) {
@@ -114,7 +111,7 @@ static void CALLBACK callback(HINTERNET request,
             unpackHeaders(res, buffer);
             free(buffer);
 
-            const char *contentLength = naettGetHeader((naettRes *)res, "Content-Length");
+            const char* contentLength = naettGetHeader((naettRes*)res, "Content-Length");
             if (!contentLength || sscanf(contentLength, "%d", &res->contentLength) != 1) {
                 res->contentLength = -1;
             }
@@ -238,8 +235,11 @@ int naettPlatformInitRequest(InternalRequest* req) {
     if (req->options.userAgent) {
         uaBuf = winFromUTF8(req->options.userAgent);
     }
-    req->session = WinHttpOpen(
-        uaBuf ? uaBuf : _T(NAETT_UA), WINHTTP_ACCESS_TYPE_NO_PROXY, WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, WINHTTP_FLAG_ASYNC);
+    req->session = WinHttpOpen(uaBuf ? (LPCWSTR)uaBuf : _T(NAETT_UA),
+        WINHTTP_ACCESS_TYPE_NO_PROXY,
+        WINHTTP_NO_PROXY_NAME,
+        WINHTTP_NO_PROXY_BYPASS,
+        WINHTTP_FLAG_ASYNC);
     free(uaBuf);
 
     if (!req->session) {

--- a/src/naett_win.c
+++ b/src/naett_win.c
@@ -235,7 +235,7 @@ int naettPlatformInitRequest(InternalRequest* req) {
     if (req->options.userAgent) {
         uaBuf = winFromUTF8(req->options.userAgent);
     }
-    req->session = WinHttpOpen(uaBuf ? (LPCWSTR)uaBuf : _T(NAETT_UA),
+    req->session = WinHttpOpen((uaBuf ? uaBuf : _T(NAETT_UA)),
         WINHTTP_ACCESS_TYPE_NO_PROXY,
         WINHTTP_NO_PROXY_NAME,
         WINHTTP_NO_PROXY_BYPASS,

--- a/src/naett_win.c
+++ b/src/naett_win.c
@@ -144,10 +144,7 @@ static void CALLBACK callback(HINTERNET request,
                 break;
             }
 
-            size_t bytesToRead = res->bytesLeft;
-            if (bytesToRead > sizeof(res->buffer)) {
-                bytesToRead = sizeof(res->buffer);
-            }
+            size_t bytesToRead = min(res->bytesLeft, sizeof(res->buffer));
             if (!WinHttpReadData(request, res->buffer, (DWORD)bytesToRead, NULL)) {
                 res->code = naettReadError;
                 res->complete = 1;
@@ -165,10 +162,7 @@ static void CALLBACK callback(HINTERNET request,
             res->totalBytesRead += (int)bytesRead;
             res->bytesLeft -= bytesRead;
             if (res->bytesLeft > 0) {
-                size_t bytesToRead = res->bytesLeft;
-                if (bytesToRead > sizeof(res->buffer)) {
-                    bytesToRead = sizeof(res->buffer);
-                }
+                size_t bytesToRead = min(res->bytesLeft, sizeof(res->buffer));
                 if (!WinHttpReadData(request, res->buffer, (DWORD)bytesToRead, NULL)) {
                     res->code = naettReadError;
                     res->complete = 1;

--- a/src/naett_win.c
+++ b/src/naett_win.c
@@ -66,6 +66,7 @@ static LPCWSTR packHeaders(InternalRequest* req) {
 
 static void unpackHeaders(InternalResponse* res, LPWSTR packed) {
     size_t len = 0;
+    KVLink* firstHeader = NULL;
     while ((len = wcslen(packed)) != 0) {
         char* header = winToUTF8(packed);
         char* split = strchr(header, ':');
@@ -78,12 +79,13 @@ static void unpackHeaders(InternalResponse* res, LPWSTR packed) {
             naettAlloc(KVLink, node);
             node->key = strdup(header);
             node->value = strdup(split);
-            node->next = res->headers;
-            res->headers = node;
+            node->next = firstHeader;
+            firstHeader = node;
         }
         free(header);
         packed += len + 1;
     }
+    res->headers = firstHeader;
 }
 
 static void CALLBACK callback(HINTERNET request,

--- a/src/naett_win.c
+++ b/src/naett_win.c
@@ -114,6 +114,11 @@ static void CALLBACK callback(HINTERNET request,
             unpackHeaders(res, buffer);
             free(buffer);
 
+            const char *contentLength = naettGetHeader((naettRes *)res, "Content-Length");
+            if (!contentLength || sscanf(contentLength, "%d", &res->contentLength) != 1) {
+                res->contentLength = -1;
+            }
+
             DWORD statusCode = 0;
             DWORD statusCodeSize = sizeof(statusCode);
 
@@ -154,7 +159,7 @@ static void CALLBACK callback(HINTERNET request,
                 res->code = naettReadError;
                 res->complete = 1;
             }
-
+            res->totalBytesRead += (int)bytesRead;
             res->bytesLeft -= bytesRead;
             if (res->bytesLeft > 0) {
                 size_t bytesToRead = min(res->bytesLeft, sizeof(res->buffer));

--- a/src/naett_win.c
+++ b/src/naett_win.c
@@ -144,7 +144,10 @@ static void CALLBACK callback(HINTERNET request,
                 break;
             }
 
-            size_t bytesToRead = min(res->bytesLeft, sizeof(res->buffer));
+            size_t bytesToRead = res->bytesLeft;
+            if (bytesToRead > sizeof(res->buffer)) {
+                bytesToRead = sizeof(res->buffer);
+            }
             if (!WinHttpReadData(request, res->buffer, (DWORD)bytesToRead, NULL)) {
                 res->code = naettReadError;
                 res->complete = 1;
@@ -162,7 +165,10 @@ static void CALLBACK callback(HINTERNET request,
             res->totalBytesRead += (int)bytesRead;
             res->bytesLeft -= bytesRead;
             if (res->bytesLeft > 0) {
-                size_t bytesToRead = min(res->bytesLeft, sizeof(res->buffer));
+                size_t bytesToRead = res->bytesLeft;
+                if (bytesToRead > sizeof(res->buffer)) {
+                    bytesToRead = sizeof(res->buffer);
+                }
                 if (!WinHttpReadData(request, res->buffer, (DWORD)bytesToRead, NULL)) {
                     res->code = naettReadError;
                     res->complete = 1;

--- a/testrig/Makefile
+++ b/testrig/Makefile
@@ -1,6 +1,7 @@
 CFLAGS = -I.. -g -Wall -pedantic -DINCLUDE_MAIN
 
 ifeq ($(OS),Windows_NT)
+	CFLAGS += -DUNICODE
 	LDFLAGS = -lwinhttp
 else
 	UNAME_S := $(shell uname -s)

--- a/testrig/test.c
+++ b/testrig/test.c
@@ -8,7 +8,7 @@
 #include <android/log.h>
 #define LOG(...) ((void)__android_log_print(ANDROID_LOG_INFO, "naett", __VA_ARGS__))
 #else
-#define LOG(...) printf
+#define LOG(...) printf(__VA_ARGS__)
 #endif // __ANDROID__
 
 int fail(const char* where, const char* message) {


### PR DESCRIPTION
Replaces PR #18.

> This lets you implement a progress bar for downloads safely and efficiently by calling naettGetTotalBytesRead() after checking naettComplete() and finding out it's not done yet.
> 
> The first commit makes sure that res->headers only gets written to once by the various backends. This is not actually needed for the two later commits, and still doesn't technically make it safe to read headers before the full request is complete (although in practice it'll be), but it's still good practice and probably a slight performance improvement. Not implemented in linux.c though because it's less convenient to do there.
> 
> Fixes https://github.com/erkkah/naett/issues/16