### PR TITLE
Android: Build fix for compilers shipped with new NDK versions

### DIFF
--- a/naett.c
+++ b/naett.c
@@ -1445,6 +1445,8 @@ int naettPlatformInitRequest(InternalRequest* req) {
 }
 
 static void* processRequest(void* data) {
+    const int bufSize = 10240;
+    char byteBuffer[bufSize];
     InternalResponse* res = (InternalResponse*)data;
     InternalRequest* req = res->request;
 
@@ -1492,9 +1494,7 @@ static void* processRequest(void* data) {
         goto finally;
     }
 
-    const int bufSize = 10240;
     jbyteArray buffer = (*env)->NewByteArray(env, bufSize);
-    char byteBuffer[bufSize];
 
     if (outputStream != NULL) {
         int bytesRead = 0;

--- a/src/naett_android.c
+++ b/src/naett_android.c
@@ -95,6 +95,8 @@ int naettPlatformInitRequest(InternalRequest* req) {
 }
 
 static void* processRequest(void* data) {
+    const int bufSize = 10240;
+    char byteBuffer[bufSize];
     InternalResponse* res = (InternalResponse*)data;
     InternalRequest* req = res->request;
 
@@ -142,9 +144,7 @@ static void* processRequest(void* data) {
         goto finally;
     }
 
-    const int bufSize = 10240;
     jbyteArray buffer = (*env)->NewByteArray(env, bufSize);
-    char byteBuffer[bufSize];
 
     if (outputStream != NULL) {
         int bytesRead = 0;


### PR DESCRIPTION
In modern versions of LLVM, can't goto past a variable declaration, oops.

Hopefully the last of this batch of changes :)

Later I'm considering adding a mechanism for naett to spawn threads using a callback (so you can use your own threadpool), but not anytime soon.

See https://github.com/hrydgard/ppsspp/issues/17583