### PR TITLE
Android: Fix small local reference leak

### DIFF
--- a/naett.c
+++ b/naett.c
@@ -1485,6 +1485,7 @@ static void* processRequest(void* data) {
     }
     jobject methodString = (*env)->NewStringUTF(env, req->options.method);
     voidCall(env, connection, "setRequestMethod", "(Ljava/lang/String;)V", methodString);
+    (*env)->DeleteLocalRef(env, methodString);
     voidCall(env, connection, "setConnectTimeout", "(I)V", req->options.timeoutMS);
     voidCall(env, connection, "setInstanceFollowRedirects", "(Z)V", 1);
 

--- a/src/naett_android.c
+++ b/src/naett_android.c
@@ -135,6 +135,7 @@ static void* processRequest(void* data) {
     }
     jobject methodString = (*env)->NewStringUTF(env, req->options.method);
     voidCall(env, connection, "setRequestMethod", "(Ljava/lang/String;)V", methodString);
+    (*env)->DeleteLocalRef(env, methodString);
     voidCall(env, connection, "setConnectTimeout", "(I)V", req->options.timeoutMS);
     voidCall(env, connection, "setInstanceFollowRedirects", "(Z)V", 1);
 


### PR DESCRIPTION
Now that my latest release is out, I'm getting crash reports - and a relatively rare one is:

```
Thread
art/runtime/indirect_reference_table.cc:132] JNI ERROR (app bug): local reference table overflow (max=512)
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
pid: 0, tid: 9090 >>> org.ppsspp.ppsspp <<<

backtrace:
  #00  pc 0x000000000004a778  /system/lib/libc.so (tgkill+12)
  #01  pc 0x0000000000047ef3  /system/lib/libc.so (pthread_kill+34)
  #02  pc 0x000000000001d949  /system/lib/libc.so (raise+10)
  #03  pc 0x0000000000019485  /system/lib/libc.so (__libc_android_abort+34)
  #04  pc 0x0000000000017448  /system/lib/libc.so (abort+4)
  #05  pc 0x000000000031c379  /system/lib/libart.so (art::Runtime::Abort(char const*)+328)
  #06  pc 0x00000000000b5405  /system/lib/libart.so (art::LogMessage::~LogMessage()+1132)
  #07  pc 0x00000000001bc89b  /system/lib/libart.so (art::IndirectReferenceTable::Add(unsigned int, art::mirror::Object*)+466)
  #08  pc 0x00000000002b52bf  /system/lib/libart.so (art::Reference_getReferent(_JNIEnv*, _jobject*)+46)
  #09  pc 0x000000000054b829  /system/framework/arm/boot.oat (java.lang.ref.Reference.getReferent+76)
  #10  pc 0x000000000054b90f  /system/framework/arm/boot.oat (java.lang.ref.Reference.get+42)
  #11  pc 0x00000000005a4bd3  /system/framework/arm/boot.oat (java.lang.ThreadLocal$ThreadLocalMap.getEntry+94)
  #12  pc 0x00000000005a4385  /system/framework/arm/boot.oat (java.lang.ThreadLocal$ThreadLocalMap.-wrap0+48)
  #13  pc 0x000000000056e33f  /system/framework/arm/boot.oat (java.lang.ThreadLocal.get+74)
  #14  pc 0x00000000005d8351  /system/framework/arm/boot-core-libart.oat (dalvik.system.BlockGuard.getThreadPolicy+44)
  #15  pc 0x000000000009d6a5  /system/framework/arm/boot-conscrypt.oat (com.android.org.conscrypt.Platform.blockGuardOnNetwork+40)
  #16  pc 0x0000000000093409  /system/framework/arm/boot-conscrypt.oat (com.android.org.conscrypt.OpenSSLSocketImpl$SSLInputStream.read+68)
  #17  pc 0x00000000000e7aa5  /system/framework/arm/boot-okhttp.oat (com.android.okhttp.okio.Okio$2.read+368)
  #18  pc 0x00000000000dc9e9  /system/framework/arm/boot-okhttp.oat (com.android.okhttp.okio.AsyncTimeout$2.read+84)
  #19  pc 0x00000000000eb459  /system/framework/arm/boot-okhttp.oat (com.android.okhttp.okio.RealBufferedSource.read+348)
  #20  pc 0x00000000000cb29f  /system/framework/arm/boot-okhttp.oat (com.android.okhttp.internal.http.HttpConnection$FixedLengthSource.read+354)
  #21  pc 0x00000000000ea5d5  /system/framework/arm/boot-okhttp.oat (com.android.okhttp.okio.RealBufferedSource$1.read+184)
  #22  pc 0x0000000000520d41  /system/framework/arm/boot.oat (java.io.InputStream.read+44)
  #23  pc 0x00000000000a9b41  /system/lib/libart.so (art_quick_invoke_stub_internal+64)
  #24  pc 0x0000000000406751  /system/lib/libart.so (art_quick_invoke_stub+232)
  #25  pc 0x00000000000b0dd5  /system/lib/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+136)
  #26  pc 0x00000000003172e9  /system/lib/libart.so (art::InvokeWithArgArray(art::ScopedObjectAccessAlreadyRunnable const&, art::ArtMethod*, art::ArgArray*, art::JValue*, char const*)+56)
  #27  pc 0x0000000000318299  /system/lib/libart.so (art::InvokeVirtualOrInterfaceWithVarArgs(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jmethodID*, std::__va_list)+256)
  #28  pc 0x0000000000268429  /system/lib/libart.so (art::JNI::CallIntMethodV(_JNIEnv*, _jobject*, _jmethodID*, std::__va_list)+444)
  #29  pc 0x00000000008d0e5f  /data/app/org.ppsspp.ppsspp-1/lib/arm/libppsspp_jni.so (intCall)
  #30  pc 0x00000000008d0bf9  /data/app/org.ppsspp.ppsspp-1/lib/arm/libppsspp_jni.so (processRequest)
  #31  pc 0x00000000000479c3  /system/lib/libc.so (__pthread_start(void*)+22)
  #32  pc 0x0000000000019ed1  /system/lib/libc.so (__start_thread+6)
```

At the bottom is processRequest from naett.

This caused me to have a look, and all I find is this one.