### PR TITLE
Fixed memory issue where NSURLSessionConfiguration was never retained

### DIFF
--- a/naett.c
+++ b/naett.c
@@ -630,6 +630,7 @@ void naettPlatformInit(naettInitData initData) {
     }
 
     sessionConfiguration = objc_msgSend_id(class("NSURLSessionConfiguration"), sel("ephemeralSessionConfiguration"));
+    retain(sessionConfiguration);
 }
 
 id NSString(const char* string) {

--- a/src/naett_osx.c
+++ b/src/naett_osx.c
@@ -34,6 +34,7 @@ void naettPlatformInit(naettInitData initData) {
     }
 
     sessionConfiguration = objc_msgSend_id(class("NSURLSessionConfiguration"), sel("ephemeralSessionConfiguration"));
+    retain(sessionConfiguration);
 }
 
 id NSString(const char* string) {


### PR DESCRIPTION
This PR fixes a memory issue on macOS / iOS. The `sessionConfiguration` object is now retained in the `naettInit` function. 
Note, since there is currently no deinit function in the `naett` library, the single `sessionConfiguration` object created during `naettInit` is never released.